### PR TITLE
Bugfix/new faucet contract

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "liveServer.settings.port": 5502
+}

--- a/assets/javascript/abis/faucetAbi.js
+++ b/assets/javascript/abis/faucetAbi.js
@@ -91,4 +91,4 @@ const faucetAbi = [
 		"type": "event"
 	}
 ]
-const faucetAddress = "0x534361FCfAb1b636469E3c53a34764D4a352C8d3";
+const faucetAddress = "0xd688b0815fD9E1b6fFe330cB8C1b30bA56762f55";

--- a/assets/javascript/abis/faucetAbi.js
+++ b/assets/javascript/abis/faucetAbi.js
@@ -2,42 +2,10 @@ const faucetAbi = [
 	{
 		"constant": false,
 		"inputs": [],
-		"name": "withdrawTok",
-		"outputs": [],
-		"payable": false,
-		"stateMutability": "nonpayable",
-		"type": "function"
-	},
-	{
-		"constant": true,
-		"inputs": [],
-		"name": "rate",
-		"outputs": [
-			{
-				"name": "",
-				"type": "uint256"
-			}
-		],
-		"payable": false,
-		"stateMutability": "view",
-		"type": "function"
-	},
-	{
-		"constant": false,
-		"inputs": [],
 		"name": "withdrawEther",
 		"outputs": [],
 		"payable": false,
 		"stateMutability": "nonpayable",
-		"type": "function"
-	},
-	{
-		"constant": false,
-		"inputs": [],
-		"name": "buyZap",
-		"outputs": [],
-		"payable": true,
-		"stateMutability": "payable",
 		"type": "function"
 	},
 	{
@@ -52,6 +20,24 @@ const faucetAbi = [
 		],
 		"payable": false,
 		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"constant": false,
+		"inputs": [
+			{
+				"name": "to",
+				"type": "address"
+			},
+			{
+				"name": "amt",
+				"type": "uint256"
+			}
+		],
+		"name": "buyZap",
+		"outputs": [],
+		"payable": true,
+		"stateMutability": "payable",
 		"type": "function"
 	},
 	{
@@ -104,6 +90,5 @@ const faucetAbi = [
 		"name": "Log",
 		"type": "event"
 	}
-];
-
-const faucetAddress = "0xE4304d24F352349CC4dA0ecDEa7FFa1924959B93";
+]
+const faucetAddress = "0x534361FCfAb1b636469E3c53a34764D4a352C8d3";

--- a/assets/javascript/main.js
+++ b/assets/javascript/main.js
@@ -14,7 +14,7 @@ $(document).ready(() => {
     });
 
 
-    // On click of the get-zap button this function starts the transaction to send users 1 ZAP
+    // On click of the get-zap button this function starts the transaction to send users 1000 ZAP
     $('#get-zap').click(async () => {
 
         // Gets the users account address
@@ -25,9 +25,10 @@ $(document).ready(() => {
         let faucetContract = await new web3.eth.Contract(faucetAbi, faucetAddress);
 
         // Converts the wei amount to a BigNumber
+        // 1000000000000000000 wei = 1000 ZAP
         let value = web3.utils.toBN(1000000000000000000);
 
-        // Selects the functions used by the Faucet.sol smart contract
+        // Selects the buyZap function
         faucetContract.methods.buyZap(accounts[0], value
 
         ).send({ from: accounts[0], value: 1000000000000000 })

--- a/assets/javascript/main.js
+++ b/assets/javascript/main.js
@@ -24,15 +24,13 @@ $(document).ready(() => {
         // and passing the contracts ABI and Address as agruments
         let faucetContract = await new web3.eth.Contract(faucetAbi, faucetAddress);
 
+        // Converts the wei amount to a BigNumber
+        let value = web3.utils.toBN(1000000000000000000);
+
         // Selects the functions used by the Faucet.sol smart contract
-        faucetContract.methods
+        faucetContract.methods.buyZap(accounts[0], value
 
-            // Function invoked from the Faucet.sol smart contract
-            .buyZap()
-
-            // The from property specifies the address invoking the function
-            // The value property is measured in wei then converted to ETH then ZAP
-            .send({ from: accounts[0], value: 1000000000000000 })
+        ).send({ from: accounts[0], value: 1000000000000000 })
 
             // Successful promise
             .then((res) => {

--- a/assets/javascript/ripples.js
+++ b/assets/javascript/ripples.js
@@ -1,5 +1,0 @@
-$(document).ready(function () {
-    $('.container-fluid').ripples({
-        resolution:400
-    });
-});

--- a/assets/style/index.css
+++ b/assets/style/index.css
@@ -1,6 +1,7 @@
 body {
     font-family: Arial, Helvetica, sans-serif;
     overflow: hidden;
+    background-color: rgb(80, 80, 80);
 
 }
 
@@ -10,7 +11,6 @@ body {
     height: 100vh;
     background: url('../images//solid-black.jpg') center center;
   
-   
 }
 
 #copy-address {

--- a/index.html
+++ b/index.html
@@ -85,10 +85,10 @@
 
       <!-- Kovan Ether Faucet Div -->
       <div class='description-div'>
-        <!-- <h5>Kovan Ether Faucet Link</h5>
-        <a href='https://faucet.kovan.network/' target='_blank'>
-          <p id='faucet-link'>https://faucet.kovan.network/</p>
-        </a> -->
+        <h5>Kovan Ether Faucet Link</h5>
+        <a href='https://gitter.im/kovan-testnet/faucet' target='_blank'>
+          <p id='faucet-link'>https://gitter.im/kovan-testnet/faucet</p>
+        </a>
       </div>
 
       <!-- Get Zap Div -->

--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
 
         <h5 id='address-heading'>Zap Token Contract Address</h5>
 
-        <input id='copy-address' value='0xfD948De3b5Cd4A9B757399179C800DBaA0001ad6' readonly>
+        <input id='copy-address' value='0x7F6E5FdEb90Bb23Ab130D671E6D7Cf4a8Eb1e45b' readonly>
 
         <!-- Clipboard icon -->
         <svg width="1.5em" height="1.5em" viewBox="0 0 16 16" class="bi bi-clipboard" fill="whitesmoke"

--- a/index.html
+++ b/index.html
@@ -22,7 +22,6 @@
 
 <body>
 
-
   <!-- Bootstrap Topbar -->
   <nav class="navbar navbar-light bg-light justify-content-between topbar sticky-top">
     <a href='https://zap.org/'>
@@ -55,7 +54,7 @@
 
         <h5 id='address-heading'>Zap Token Contract Address</h5>
 
-        <input id='copy-address' value='0x986F46A34b8adD47593074Acd804E2D622643D72' readonly>
+        <input id='copy-address' value='0xfD948De3b5Cd4A9B757399179C800DBaA0001ad6' readonly>
 
         <!-- Clipboard icon -->
         <svg width="1.5em" height="1.5em" viewBox="0 0 16 16" class="bi bi-clipboard" fill="whitesmoke"
@@ -76,9 +75,8 @@
         <h5>Faucet Description</h5>
         <p>
           The Zap Faucet is a developer tool running on the Ethereum Kovan Testnet
-          able to send 1 Test ZAP to a users
-          MetaMask account. Use the Kovan Ether Faucet Link below to get
-          1 Ether before starting the transaction. Copy the Zap
+          able to send 1000 Test ZAP to a users
+          MetaMask account. Copy the Zap
           Token Contract address above and add it to your MetaMask
           account and start the transaction by clicking the Get
           ZAP button.

--- a/index.html
+++ b/index.html
@@ -85,10 +85,10 @@
 
       <!-- Kovan Ether Faucet Div -->
       <div class='description-div'>
-        <h5>Kovan Ether Faucet Link</h5>
+        <!-- <h5>Kovan Ether Faucet Link</h5>
         <a href='https://faucet.kovan.network/' target='_blank'>
           <p id='faucet-link'>https://faucet.kovan.network/</p>
-        </a>
+        </a> -->
       </div>
 
       <!-- Get Zap Div -->


### PR DESCRIPTION
## Summary 
The previous ZapToken address in the Faucet and the ZapToken address in Alpha were not the same making the test ZAP incompatible with the Alpha features. Used the newly deployed contract information to make the test ZAP  from the Faucet compatible with the Alpha features.

## Implementation
- A new ZapToken contract was deployed to the Kovan test net and allocated test ZAP to the new Faucet contract
- Set the new Faucet address and ABI to create a contract instance
- Converted the 1000000000000000000 wei value to a BigNumber so the transaction can handle it
- The 1000000000000000000 wei value converts to 1000 test ZAP
- Changed the ZapToken address in the clipboard
- Removed the old Eth Kovan Faucet link to the Gitter Kovan Faucet link
- Removed the jQuery ripple effect
- Removed the js file for the ripple effect

## Files
```assets\javascript\abis\faucetAbi.js ```
```assets\javascript\main.js ```
``` assets\style\index.css```
``` index.html```
``` assets/javascript/ripples.js``` Deleted

## Visual Preview
New ZapToken Contract address to add the test ZAP to the users MetaMask
![Screenshot (225)](https://user-images.githubusercontent.com/42893948/112530262-a0e8bb00-8d7c-11eb-979f-dc0ef75fab05.png)

Account before using the Faucet
![Screenshot (227)](https://user-images.githubusercontent.com/42893948/112530501-e3aa9300-8d7c-11eb-90ab-f0a86ee0f6bf.png)

Account after using the Faucet
![Screenshot (229)](https://user-images.githubusercontent.com/42893948/112530804-41d77600-8d7d-11eb-8685-3197b5f6b230.png)

